### PR TITLE
run lenses proposition of changes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -723,7 +723,6 @@ class MetalsLanguageServer(
             semanticdbs,
             compilers,
             statusBar,
-            () => userConfig,
           )
         )
         scalafixProvider = ScalafixProvider(
@@ -2078,28 +2077,6 @@ class MetalsLanguageServer(
       case ServerCommands.NewScalaProject() =>
         newProjectProvider.createNewProjectFromTemplate().asJavaObject
 
-      case ServerCommands.DiscoverJvmRunCommand(unresolvedParams) =>
-        import JsonParser._
-        debugProvider
-          .debugDiscovery(unresolvedParams)
-          .map { params =>
-            params.getData match {
-              case json: JsonElement
-                  if params.getDataKind == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS =>
-                json.as[b.ScalaMainClass] match {
-                  case Success(main) if params.getTargets().size > 0 =>
-                    val updatedData = debugProvider.extendScalaMainClass(
-                      main,
-                      params.getTargets().get(0),
-                    )
-                    params.setData(updatedData)
-                  case _ =>
-                }
-
-            }
-            params
-          }
-          .asJavaObject
       case ServerCommands.CopyWorksheetOutput(path) =>
         val worksheetPath = path.toAbsolutePath
         val output = worksheetProvider.copyWorksheetOutput(worksheetPath)

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -231,23 +231,6 @@ object ServerCommands {
        |""".stripMargin,
   )
 
-  val DiscoverJvmRunCommand = new ParametrizedCommand[DebugDiscoveryParams](
-    "discover-jvm-run-command",
-    "Discover main classes to run.",
-    """|Gets the DebugSession object that also contains a command to run in shell based 
-       |on JVM environment including classpath, jvmOptions and environment parameters.
-       |""".stripMargin,
-    """|DebugUnresolvedTestClassParams object
-       |Example:
-       |```json
-       |{
-       |   testClass: "com.foo.FooSuite",
-       |   buildTarget: "foo"
-       |}
-       |```
-       |""".stripMargin,
-  )
-
   val StartDebugAdapter = new Command(
     "debug-adapter-start",
     "Start debug adapter",
@@ -616,7 +599,6 @@ object ServerCommands {
       GotoSymbol,
       ImportBuild,
       InsertInferredType,
-      DiscoverJvmRunCommand,
       NewScalaFile,
       NewJavaFile,
       NewScalaProject,

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -223,7 +223,8 @@ final class RunTestCodeLens(
     val data = buildTargets
       .jvmRunEnvironment(target)
       .zip(userConfig().usedJavaBinary) match {
-      case None => main.toJson
+      case None =>
+        main.toJson
       case Some((env, javaHome)) =>
         ExtendedScalaMainClass(main, env, javaHome).toJson
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -42,7 +42,6 @@ import scala.meta.internal.metals.ScalaTestSuitesDebugRequest
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
-import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
 import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
@@ -87,7 +86,6 @@ class DebugProvider(
     semanticdbs: Semanticdbs,
     compilers: Compilers,
     statusBar: StatusBar,
-    userConfig: () => UserConfiguration,
 ) extends Cancelable {
 
   import DebugProvider._
@@ -608,19 +606,6 @@ class DebugProvider(
       _ <- ensureNoWorkspaceErrors(List(request.target))
       result <- makeDebugSession()
     } yield result
-  }
-
-  def extendScalaMainClass(
-      main: ScalaMainClass,
-      targetId: BuildTargetIdentifier,
-  ): JsonElement = {
-    buildTargets
-      .jvmRunEnvironment(targetId)
-      .zip(userConfig().usedJavaBinary) match {
-      case None => main.toJson
-      case Some((env, javaHome)) =>
-        ExtendedScalaMainClass(main, env, javaHome).toJson
-    }
   }
 
   private val reportErrors: PartialFunction[Throwable, Unit] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
@@ -27,7 +27,6 @@ import ch.epfl.scala.{bsp4j => b}
  * - allow new clients to use shellCommand to run the main class directly in e.g. terminal
  */
 case class ExtendedScalaMainClass private (
-    kind: "scala-main-class",
     `class`: String,
     arguments: java.util.List[String],
     jvmOptions: java.util.List[String],
@@ -36,8 +35,6 @@ case class ExtendedScalaMainClass private (
 )
 
 object ExtendedScalaMainClass {
-  final val kind: "scala-main-class" = "scala-main-class"
-
   private def createCommand(
       javaHome: AbsolutePath,
       classpath: List[String],
@@ -67,7 +64,6 @@ object ExtendedScalaMainClass {
         .asScala).toList.asJava
 
     ExtendedScalaMainClass(
-      kind,
       main.getClassName(),
       main.getArguments(),
       jvmOpts.asJava,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
@@ -8,7 +8,26 @@ import scala.meta.io.AbsolutePath
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.{bsp4j => b}
 
-case class ExtendedScalaMainClass private(
+/**
+ * Wrapper around the bsp4j.ScalaMainClass to provide additional information which may be used by client.
+ *
+ * For backward compatibility reasons, it provides the same fields as the bsp4j.ScalaMainClass,
+ * so it's safe for older clients to work without any change:
+ * @param class the fully qualified name of the class
+ * @param arguments the arguments to pass to the main method
+ * @param jvmOptions the jvm options to pass to the jvm
+ * @param environmentVariables the environment variables to pass to the process
+ *
+ * However, it also provides two additional fields:
+ * @param kind allows client to distinguish between old, bsp4j.ScalaMainClass and new ExtendedScalaMainClass
+ * @param shellCommand which is the command to run in the shell to start the main class
+ * ---
+ * To sum up:
+ * - allow old clients to work without any change
+ * - allow new clients to use shellCommand to run the main class directly in e.g. terminal
+ */
+case class ExtendedScalaMainClass private (
+    kind: "scala-main-class",
     `class`: String,
     arguments: java.util.List[String],
     jvmOptions: java.util.List[String],
@@ -17,6 +36,7 @@ case class ExtendedScalaMainClass private(
 )
 
 object ExtendedScalaMainClass {
+  final val kind: "scala-main-class" = "scala-main-class"
 
   private def createCommand(
       javaHome: AbsolutePath,
@@ -47,6 +67,7 @@ object ExtendedScalaMainClass {
         .asScala).toList.asJava
 
     ExtendedScalaMainClass(
+      kind,
       main.getClassName(),
       main.getArguments(),
       jvmOpts.asJava,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
@@ -8,7 +8,7 @@ import scala.meta.io.AbsolutePath
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.{bsp4j => b}
 
-case class ExtendedScalaMainClass(
+case class ExtendedScalaMainClass private(
     `class`: String,
     arguments: java.util.List[String],
     jvmOptions: java.util.List[String],


### PR DESCRIPTION
I removed support of `discover-jvm-run-command`, I think that we were trying to bite off more than we could chew and it's better to keep this PR simpler, with better goal.
Lets start with code lenses working and then we can think of adding `discover-jvm-run-command` again.

My idea is following:
- extend in backward compatible way run lenses. Allow old clients to use them as before, but at the same time allow new clients to take advantage of `shellCommand`
- IMO this old vs new needs crystal clear distinction - I used `shellCommand` as a discriminator on frontend. Anyway, this has to be somewhere documented and written explicitely. Code lenses lacks proper documentation on metals website, maybe it's a good opportunity to create it?

PR with vscode-suggestion - https://github.com/tgodzik/metals-vscode/pull/1
